### PR TITLE
Enable prefixed lin_malloc symbols and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,12 @@ file(GLOB IGRIS_SOURCES
 	igris/trent/*.cpp
 	igris/datastruct/*.cpp
 	igris/protocols/gstuff.cpp
-	igris/protocols/gstuff_v1/gstuff.c
-	igris/protocols/gstuff_v1/autorecv.c
-	igris/sync/syslock_mutex.cpp
-	igris/sync/semaphore.cpp
-	igris/string/replace_substrings.c
+        igris/protocols/gstuff_v1/gstuff.c
+        igris/protocols/gstuff_v1/autorecv.c
+        igris/sync/syslock_mutex.cpp
+        igris/sync/semaphore.cpp
+        igris/sync/critical_context.c
+        igris/string/replace_substrings.c
 	igris/string/replace.cpp
 	igris/string/hexascii_string.cpp
 	igris/string/memmem.c

--- a/compat/mem/lin_malloc.cpp
+++ b/compat/mem/lin_malloc.cpp
@@ -42,6 +42,14 @@
 //#include "sectionname.h"
 //#include "stdlib_private.h"
 
+#ifndef LIN_MALLOC_MALLOC
+#define LIN_MALLOC_MALLOC malloc
+#endif
+
+#ifndef LIN_MALLOC_FREE
+#define LIN_MALLOC_FREE free
+#endif
+
 /*
  * Exported interface:
  *
@@ -68,9 +76,9 @@ struct __freelist *__flp = NULL;
 
 extern "C" unsigned int is_interrupt_context();
 
-extern "C" void *malloc(size_t len) __attribute__((used));
+extern "C" void *LIN_MALLOC_MALLOC(size_t len) __attribute__((used));
 // ATTRIBUTE_CLIB_SECTION
-void *malloc(size_t len)
+void *LIN_MALLOC_MALLOC(size_t len)
 {
     if (critical_context_level() > 0)
         abort();
@@ -204,9 +212,9 @@ void *malloc(size_t len)
 }
 
 // ATTRIBUTE_CLIB_SECTION
-extern "C" void free(void *p) __attribute__((used));
+extern "C" void LIN_MALLOC_FREE(void *p) __attribute__((used));
 
-void free(void *p)
+void LIN_MALLOC_FREE(void *p)
 {
     /* ISO C says free(NULL) must be a no-op */
     if (p == 0)

--- a/tests/lin_malloc_env.cpp
+++ b/tests/lin_malloc_env.cpp
@@ -1,0 +1,17 @@
+// Helper translation unit that compiles the AVR-style allocator sources
+// under alternative symbol names so they can coexist with libc on the host.
+//
+// By redefining malloc/free/realloc before including the implementation files
+// we obtain lin_malloc_malloc/lin_malloc_free/lin_malloc_realloc symbols that
+// unit tests can call without overriding the system allocator.
+
+#define LIN_MALLOC_MALLOC lin_malloc_malloc
+#define LIN_MALLOC_FREE lin_malloc_free
+#define LIN_MALLOC_REALLOC lin_malloc_realloc
+
+#include "../compat/mem/lin_malloc.cpp"
+#include "../compat/mem/lin_realloc.cpp"
+
+#undef LIN_MALLOC_MALLOC
+#undef LIN_MALLOC_FREE
+#undef LIN_MALLOC_REALLOC

--- a/tests/lin_malloc_tests.cpp
+++ b/tests/lin_malloc_tests.cpp
@@ -1,0 +1,90 @@
+#include "doctest/doctest.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "../compat/mem/lin_malloc.h"
+
+extern "C" {
+void *lin_malloc_malloc(size_t len);
+void lin_malloc_free(void *p);
+void *lin_malloc_realloc(void *ptr, size_t len);
+
+extern char *__malloc_heap_start;
+extern char *__brkval;
+extern __freelist *__flp;
+extern int __allocation_counter;
+}
+
+// Provide the linker symbol that the allocator expects as the start of SRAM.
+char _heap_start;
+
+namespace
+{
+    constexpr size_t kFakeHeapSize = 2048;
+    alignas(std::max_align_t) std::array<unsigned char, kFakeHeapSize>
+        fake_heap;
+
+    void reset_fake_heap()
+    {
+        std::fill(fake_heap.begin(), fake_heap.end(), 0);
+        __malloc_heap_start = reinterpret_cast<char *>(fake_heap.data());
+        __brkval = nullptr;
+        __flp = nullptr;
+        __allocation_counter = 0;
+    }
+
+    bool pointer_in_heap(void *ptr, size_t size)
+    {
+        auto *begin = fake_heap.data();
+        auto *end = fake_heap.data() + fake_heap.size();
+        auto *cptr = static_cast<unsigned char *>(ptr);
+        return cptr >= begin && (cptr + size) <= end;
+    }
+}
+
+TEST_CASE("lin_malloc allocates inside the fake heap buffer")
+{
+    reset_fake_heap();
+
+    auto *ptr = static_cast<unsigned char *>(lin_malloc_malloc(32));
+    REQUIRE(ptr != nullptr);
+    CHECK(pointer_in_heap(ptr, 32));
+    CHECK(__allocation_counter == 1);
+}
+
+TEST_CASE("lin_malloc_free returns blocks to the freelist")
+{
+    reset_fake_heap();
+
+    auto *ptr = lin_malloc_malloc(48);
+    auto *ptr2 = lin_malloc_malloc(16);
+    REQUIRE(ptr != nullptr);
+    REQUIRE(ptr2 != nullptr);
+
+    lin_malloc_free(ptr);
+    auto *reused = lin_malloc_malloc(40);
+    CHECK(reused == ptr);
+
+    lin_malloc_free(ptr2);
+    lin_malloc_free(reused);
+
+    auto *merged = lin_malloc_malloc(80);
+    CHECK(merged != nullptr);
+    CHECK(pointer_in_heap(merged, 80));
+}
+
+TEST_CASE("lin_malloc_realloc can grow within the fake heap")
+{
+    reset_fake_heap();
+
+    auto *ptr = static_cast<unsigned char *>(lin_malloc_malloc(32));
+    REQUIRE(pointer_in_heap(ptr, 32));
+
+    auto *grown = static_cast<unsigned char *>(lin_malloc_realloc(ptr, 64));
+    REQUIRE(grown != nullptr);
+    CHECK(pointer_in_heap(grown, 64));
+}


### PR DESCRIPTION
## Summary
- allow the embedded allocator sources to be compiled under alternate symbol names so we can link them next to the host libc during testing
- plug the missing `critical_context` object file into the CMake build and exercise the allocator with a fake heap via doctest scenarios

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4`
- `./build/igris_test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b07c2a4a0832ea31adfe3e17c3972)